### PR TITLE
Add chat gpt memories

### DIFF
--- a/lib/features/authentication/pages/login_page.dart
+++ b/lib/features/authentication/pages/login_page.dart
@@ -42,7 +42,6 @@ class LoginPage extends ConsumerWidget {
                   ),
                 ),
                 keyboardType: TextInputType.emailAddress,
-                readOnly: state.isLoggingIn,
                 textCapitalization: TextCapitalization.none,
                 textInputAction: TextInputAction.next,
                 onChanged: (value) {

--- a/lib/features/authentication/pages/register_page.dart
+++ b/lib/features/authentication/pages/register_page.dart
@@ -36,7 +36,6 @@ class RegisterPage extends ConsumerWidget {
                   labelText: 'Email',
                 ),
                 keyboardType: TextInputType.emailAddress,
-                readOnly: state.registering,
                 textCapitalization: TextCapitalization.none,
                 textInputAction: TextInputAction.next,
                 onChanged: registerStateNotifier.setEmail,

--- a/lib/features/chat/models/principle.dart
+++ b/lib/features/chat/models/principle.dart
@@ -1,0 +1,20 @@
+class Principle {
+  final List<String> tags;
+  final String text;
+
+  Principle({required this.tags, required this.text});
+
+  factory Principle.fromJson(Map<String, dynamic> json) {
+    final tagsList = List<String>.from(json['tags'] ?? []);
+    final text = json['text'] ?? '';
+
+    return Principle(tags: tagsList, text: text);
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'tags': tags,
+      'text': text,
+    };
+  }
+}

--- a/lib/features/chat/models/principles.dart
+++ b/lib/features/chat/models/principles.dart
@@ -1,0 +1,15 @@
+import 'package:gptmoe/features/chat/models/principle.dart';
+
+class Principles {
+  List<Principle> list;
+
+  Principles({required this.list});
+
+  factory Principles.fromJson(Map<String, dynamic> json) {
+    return Principles(
+      list: List<Principle>.from(
+        json['principles'].map((x) => Principle.fromJson(x)),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/pages/chat_page.dart
+++ b/lib/features/chat/pages/chat_page.dart
@@ -46,14 +46,21 @@ class _ChatPageState extends State<ChatPage> {
           builder: (context, snapshot) => StreamBuilder<List<types.Message>>(
             initialData: const [],
             stream: FirebaseChatCore.instance.messages(snapshot.data!),
-            builder: (context, snapshot) => Chat(
-              messages: snapshot.data ?? [],
-              onPreviewDataFetched: _handlePreviewDataFetched,
-              onSendPressed: _handleSendPressed,
-              user: types.User(
-                id: FirebaseChatCore.instance.firebaseUser?.uid ?? '',
-              ),
-            ),
+            builder: (context, snapshot) {
+              final allMessages = snapshot.data ?? [];
+
+              return Chat(
+                messages: allMessages,
+                onPreviewDataFetched: _handlePreviewDataFetched,
+                onSendPressed: (message) => _handleSendPressed(
+                  message: message,
+                  allMessages: allMessages,
+                ),
+                user: types.User(
+                  id: FirebaseChatCore.instance.firebaseUser?.uid ?? '',
+                ),
+              );
+            },
           ),
         ),
       );
@@ -67,15 +74,19 @@ class _ChatPageState extends State<ChatPage> {
     FirebaseChatCore.instance.updateMessage(updatedMessage, widget.room.id);
   }
 
-  void _handleSendPressed(types.PartialText message) async {
+  void _handleSendPressed({
+    required types.PartialText message,
+    required List<types.Message> allMessages,
+  }) async {
     FirebaseChatCore.instance.sendMessage(
       message,
       widget.room.id,
     );
 
     ChatGptService.sendReplyMessageFromChatGpt(
-      message.text,
-      widget.room.id,
+      roomId: widget.room.id,
+      recentMessage: message.text,
+      allMessages: allMessages,
     );
   }
 }

--- a/lib/features/chat/services/chat_gpt_service.dart
+++ b/lib/features/chat/services/chat_gpt_service.dart
@@ -20,6 +20,15 @@ class ChatGptService {
     isLogger: true,
   );
 
+  /// Sends a reply message from the GPT-3 chatbot to the specified room ID in Firebase.
+  ///
+  /// Given a recent message and a list of all messages in the room, the method will extract
+  /// principles from the last two conversations, generate a prompt for the GPT-3 API using
+  /// the extracted principles, and send the prompt to the API to generate a response. The
+  /// response is then stored in Firestore and returned.
+  ///
+  /// Notes: This method will extract principles from the last two conversations and save them to
+  /// Firestore for future use.
   static void sendReplyMessageFromChatGpt({
     required String roomId,
     required String recentMessage,

--- a/lib/features/chat/services/chat_gpt_service.dart
+++ b/lib/features/chat/services/chat_gpt_service.dart
@@ -1,51 +1,181 @@
-import 'package:chat_gpt_sdk/chat_gpt_sdk.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter_chat_types/flutter_chat_types.dart' as types;
-import 'package:flutter_firebase_chat_core/flutter_firebase_chat_core.dart';
+import 'dart:convert';
 
-import '../../../resources/constants/chat_gpt_user.dart';
+import "package:chat_gpt_sdk/chat_gpt_sdk.dart";
+import "package:cloud_firestore/cloud_firestore.dart";
+import "package:flutter_chat_types/flutter_chat_types.dart" as types;
+import "package:flutter_firebase_chat_core/flutter_firebase_chat_core.dart";
+
+import "../../../resources/constants/chat_gpt_user.dart";
+import '../models/principle.dart';
+import '../models/principles.dart';
+import '../utils/extract_conversation.dart';
+import '../utils/get_prompt.dart';
+
+const _kLastMessageCount = 3;
 
 class ChatGptService {
-  static final openAI = OpenAI.instance.build(
+  static final _openAI = OpenAI.instance.build(
     token: '<< REPLACE WITH YOUR API KEY HERE>>',
     baseOption: HttpSetup(receiveTimeout: 6000),
     isLogger: true,
   );
 
-  static void sendReplyMessageFromChatGpt(
-    String prompt,
+  static void sendReplyMessageFromChatGpt({
+    required String roomId,
+    required String recentMessage,
+    required List<types.Message> allMessages,
+  }) async {
+    try {
+      final userId = FirebaseChatCore.instance.firebaseUser!.uid;
+
+      final lastMessageFromChatGpt = convertMessageToString(allMessages.first);
+      final lastMessageFromUser = convertMessageToString(types.TextMessage(
+        id: '',
+        author: types.User(id: userId),
+        text: recentMessage,
+      ));
+
+      final lastTwoConversation =
+          '$lastMessageFromChatGpt\n$lastMessageFromUser';
+
+      final principlesFromCurrentConversation =
+          await _convertConversationToPrinciples(lastTwoConversation);
+
+      String principlesFromCurrentConversationStringify =
+          await _getStoredPrinciplesBasedOnCurrentConversationPrinciples(
+        principlesFromCurrentConversation,
+      );
+
+      final lastMessagesStringify = allMessages
+          .take(_kLastMessageCount)
+          .map(convertMessageToString)
+          .toString();
+
+      final prompt = getPrompt(
+        recentMessage: recentMessage,
+        allMessagesStringify: lastMessagesStringify,
+        principlesFromCurrentConversationStringify:
+            principlesFromCurrentConversationStringify,
+      );
+
+      final response = await _sendPromptToOpenAI(prompt);
+
+      await _storeChatGptMessageToFireStore(response, roomId);
+
+      await _storePrinciplesBasedOnCurrentConversation(
+        principlesFromCurrentConversation,
+      );
+    } catch (_) {
+      final prompt = getPrompt(
+        recentMessage: recentMessage,
+        allMessagesStringify: '',
+        principlesFromCurrentConversationStringify: '',
+      );
+      final response = await _sendPromptToOpenAI(prompt);
+
+      await _storeChatGptMessageToFireStore(response, roomId);
+    }
+  }
+
+  static Future<String>
+      _getStoredPrinciplesBasedOnCurrentConversationPrinciples(
+    List<Principle> principles,
+  ) async {
+    String principleStringify = '';
+
+    // Loop through the tags and update the Firestore documents with the extracted principles
+    for (var principle in principles) {
+      for (final tag in principle.tags) {
+        final tagCollectionRef = FirebaseFirestore.instance
+            .collection(FirebaseChatCore.instance.config.usersCollectionName)
+            .doc(FirebaseChatCore.instance.firebaseUser?.uid)
+            .collection("memory")
+            .doc(tag)
+            .collection('principle');
+
+        final collection = await tagCollectionRef.get();
+
+        for (var doc in collection.docs) {
+          principleStringify = '$principles${doc.id} at ${doc.data()}\n';
+        }
+      }
+    }
+
+    return principleStringify;
+  }
+
+  static Future<void> _storePrinciplesBasedOnCurrentConversation(
+    List<Principle> principles,
+  ) async {
+    // Loop through the tags and update the Firestore documents with the extracted principles
+    for (var principle in principles) {
+      for (final tag in principle.tags) {
+        final tagDocRef = FirebaseFirestore.instance
+            .collection(FirebaseChatCore.instance.config.usersCollectionName)
+            .doc(FirebaseChatCore.instance.firebaseUser?.uid)
+            .collection("memory")
+            .doc(tag)
+            .collection('principle')
+            .doc(principle.text);
+
+        await tagDocRef.set({
+          'createdAt': DateTime.now(),
+        }, SetOptions(merge: true));
+      }
+    }
+  }
+
+  static Future<void> _storeChatGptMessageToFireStore(
+    String response,
     String roomId,
   ) async {
-    final request = CompleteText(
-      prompt: prompt,
-      model: kTranslateModelV3,
-    );
-
-    final response = await openAI.onCompleteText(request: request);
-
     final message = types.TextMessage.fromPartial(
+      id: "",
       author: chatGptUser,
-      id: '',
-      partialText: types.PartialText(
-          text: response!.choices.first.text.replaceAll('\n', '')),
+      partialText: types.PartialText(text: response),
     );
-
     final messageMap = message.toJson();
-    messageMap.removeWhere((key, value) => key == 'author' || key == 'id');
-    messageMap['authorId'] = 'user_id';
-    messageMap['createdAt'] = FieldValue.serverTimestamp();
-    messageMap['updatedAt'] = FieldValue.serverTimestamp();
+    messageMap.removeWhere((key, value) => key == "author" || key == "id");
+    messageMap["authorId"] = chatGptUser.id;
+    messageMap["createdAt"] = FieldValue.serverTimestamp();
+    messageMap["updatedAt"] = FieldValue.serverTimestamp();
 
     await FirebaseChatCore.instance
         .getFirebaseFirestore()
         .collection(
-            '${FirebaseChatCore.instance.config.roomsCollectionName}/$roomId/messages')
+            "${FirebaseChatCore.instance.config.roomsCollectionName}/$roomId/messages")
         .add(messageMap);
+  }
 
-    await FirebaseChatCore.instance
-        .getFirebaseFirestore()
-        .collection(FirebaseChatCore.instance.config.roomsCollectionName)
-        .doc(roomId)
-        .update({'updatedAt': FieldValue.serverTimestamp()});
+  static Future<String> _sendPromptToOpenAI(String prompt) async {
+    final response = await _openAI.onCompleteText(
+      request: CompleteText(
+        prompt: prompt,
+        model: kTranslateModelV3,
+      ),
+    );
+    return response!.choices.first.text.trim();
+  }
+
+  static Future<List<Principle>> _convertConversationToPrinciples(
+      String conversation) async {
+    final prompt = extractConversation(conversation);
+
+    final response = await _sendPromptToOpenAI(prompt);
+
+    final principles =
+        Principles.fromJson(json.decode(response) as Map<String, dynamic>);
+
+    return principles.list;
+  }
+
+  static String convertMessageToString(types.Message message) {
+    return """
+      {
+      id: ${message.author.id}
+      createdAt: ${message.author.createdAt}
+      message: ${(message as types.TextMessage).text}
+      }
+      """;
   }
 }

--- a/lib/features/chat/services/chat_gpt_service.dart
+++ b/lib/features/chat/services/chat_gpt_service.dart
@@ -105,7 +105,7 @@ class ChatGptService {
         final collection = await tagCollectionRef.get();
 
         for (var doc in collection.docs) {
-          principleStringify = '$principles${doc.id} at ${doc.data()}\n';
+          principleStringify = '${doc.id} at ${doc.data()}\n';
         }
       }
     }

--- a/lib/features/chat/utils/extract_conversation.dart
+++ b/lib/features/chat/utils/extract_conversation.dart
@@ -2,12 +2,12 @@ String extractConversation(String conversation) {
   return """
     Read the following conversation and extract principles about the user from it. 
     What are some common themes, facts, preferences, personal information, or observations about the user.
-    List out the principles and write them in very very brief sentences, also add 3 tags for each principle,
-    for the tags, use maximum 1 word with underscore and lowercased
+    List out the principles and write them in very very brief sentences, also add 3 tags (1 word tag at maximum) for each principle,
+    the tags is lowercased
     and then map each principles with the tag in this JSON format:
     {
       "principles": [
-        "tags": ["tag_1", "tag_2", "tag_3" ...],
+        "tags": ["friendly", "persuasive", "personality"],
         "text": "hi"
       ]
     }

--- a/lib/features/chat/utils/extract_conversation.dart
+++ b/lib/features/chat/utils/extract_conversation.dart
@@ -3,7 +3,7 @@ String extractConversation(String conversation) {
     Read the following conversation and extract principles about the user from it. 
     What are some common themes, facts, preferences, personal information, or observations about the user.
     List out the principles and write them in very very brief sentences, also add 3 tags for each principle,
-    for the tags, use maximum 2 word with underscore and lowercased
+    for the tags, use maximum 1 word with underscore and lowercased
     and then map each principles with the tag in this JSON format:
     {
       "principles": [

--- a/lib/features/chat/utils/extract_conversation.dart
+++ b/lib/features/chat/utils/extract_conversation.dart
@@ -1,0 +1,18 @@
+String extractConversation(String conversation) {
+  return """
+    Read the following conversation and extract principles about the user from it. 
+    What are some common themes, facts, preferences, personal information, or observations about the user.
+    List out the principles and write them in very very brief sentences, also add 3 tags for each principle,
+    for the tags, use maximum 2 word with underscore and lowercased
+    and then map each principles with the tag in this JSON format:
+    {
+      "principles": [
+        "tags": ["tag_1", "tag_2", "tag_3" ...],
+        "text": "hi"
+      ]
+    }
+    CONVERSATION (in reverse):
+    $conversation
+    Copyable JSON format with tags for each principles (make sure can the JSON format is valid):
+    """;
+}

--- a/lib/features/chat/utils/extract_conversation.dart
+++ b/lib/features/chat/utils/extract_conversation.dart
@@ -11,7 +11,7 @@ String extractConversation(String conversation) {
         "text": "hi"
       ]
     }
-    CONVERSATION (in reverse):
+    CONVERSATION
     $conversation
     Copyable JSON format with tags for each principles (make sure can the JSON format is valid):
     """;

--- a/lib/features/chat/utils/get_prompt.dart
+++ b/lib/features/chat/utils/get_prompt.dart
@@ -1,0 +1,26 @@
+String getPrompt({
+  required String recentMessage,
+  required String allMessagesStringify,
+  required String principlesFromCurrentConversationStringify,
+}) {
+  return """"
+    I am a chatbot named GPT Moe. 
+    My goals are to reduce suffering, increase prosperity, and increase understanding. 
+    I will read the conversation notes and recent messages, and then I will provide 
+    an answer that make sense and just like a human. 
+    I will then end my response with a follow-up or leading question.
+    The following are notes from earlier conversations with USER:
+    $principlesFromCurrentConversationStringify
+
+    The following are the most recent messages in the conversation in reverse (chat_gpt_user_id is GPT Moe):
+    $allMessagesStringify
+
+    And here is the latest message that you need to reply as GPT Moe:
+    $recentMessage
+
+    I will now provide a response that feels very human, followed by a question and
+    only ask to change the topic when GPT Moe feels that the user is no longer interested with current discussion,
+    don"t ask if the user still interested on the topic conversation.
+    GPT Moe:
+    """;
+}

--- a/lib/features/home/pages/home_page.dart
+++ b/lib/features/home/pages/home_page.dart
@@ -12,18 +12,11 @@ class HomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final user = ref.watch(userProvider).value;
-
-    if (user == null) {
-      return const NotAuthenticatedSection();
-    }
+    final isLoggedIn = ref.watch(isLoggedInProvider);
 
     ref.listen<bool>(isHaveRoomProvider, (_, isHaveRoom) async {
       if (!isHaveRoom) {
         final navigator = Navigator.of(context);
-
-        // TODO(zharfan104): Make to be not always create user everytime listening this
-        await FirebaseChatCore.instance.createUserInFirestore(chatGptUser);
 
         final room = await FirebaseChatCore.instance.createRoom(chatGptUser);
 
@@ -49,6 +42,10 @@ class HomePage extends ConsumerWidget {
         ),
       );
     });
+
+    if (!isLoggedIn) {
+      return const NotAuthenticatedSection();
+    }
 
     return const Center(
       child: CircularProgressIndicator(),

--- a/lib/features/home/providers/home_page_provider.dart
+++ b/lib/features/home/providers/home_page_provider.dart
@@ -10,17 +10,21 @@ final userProvider = StreamProvider<User?>((ref) {
   return auth.authStateChanges();
 });
 
-final roomsProvider = StreamProvider<List<types.Room>>((ref) {
-  return FirebaseChatCore.instance.rooms();
+final roomsProvider = FutureProvider<List<types.Room>>((ref) {
+  return FirebaseChatCore.instance.rooms().first;
 });
 
-final isHaveRoomProvider =
-    StateNotifierProvider<GenericStateNotifier<bool>, bool>((ref) {
-  final watchRooms = ref.watch(roomsProvider);
-  final rooms = watchRooms.asData?.value;
-  final isRoomExists = rooms != null && rooms.isNotEmpty;
+final isHaveRoomProvider = StateNotifierProvider<GenericStateNotifier<bool>, bool>((ref) {
+  final isLoggedIn = ref.watch(isLoggedInProvider);
+  if (isLoggedIn) {
+    final watchRooms = ref.watch(roomsProvider);
+    final rooms = watchRooms.asData?.value;
+    final isRoomExists = rooms != null && rooms.isNotEmpty;
 
-  return GenericStateNotifier<bool>(isRoomExists);
+    return GenericStateNotifier<bool>(isRoomExists);
+  }
+
+  return GenericStateNotifier<bool>(false);
 });
 
 final authenticationStateProvider = Provider((ref) {
@@ -28,7 +32,6 @@ final authenticationStateProvider = Provider((ref) {
   return user != null;
 });
 
-final isLoggedInProvider =
-    StateNotifierProvider<GenericStateNotifier<bool>, bool>(
+final isLoggedInProvider = StateNotifierProvider<GenericStateNotifier<bool>, bool>(
   (ref) => GenericStateNotifier<bool>(ref.watch(authenticationStateProvider)),
 );


### PR DESCRIPTION
Now the memory is working:

The code defines a static method sendReplyMessageFromChatGpt for the ChatGptService class that sends a message as a reply from a chatbot (named "GPT Moe") to a chat room. The method takes three required arguments: roomId is the ID of the chat room, recentMessage is the latest message received from the user, and allMessages is a list of all messages received in the chat room. The chatbot generates a reply by extracting principles from the last two messages in the conversation, concatenating them with other information, and using OpenAI's language model to generate a response. The chatbot then stores the generated response to Firestore and the extracted principles to the user's memory collection in Firestore for later use. If any error occurs during the process, the chatbot sends a fallback response without any extracted principles.

![Screenshot 2023-02-26 at 10 46 26](https://user-images.githubusercontent.com/39690358/221391190-8a83f304-3600-499e-98ca-ae607167ff54.png)
